### PR TITLE
Upgrade to .NET 6 LTS

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>TestMyCode.CSharp.API</RootNamespace>
     <Nullable>enable</Nullable>
     <AssemblyName>TestMyCode.CSharp.API</AssemblyName>

--- a/Bootstrap/Bootstrap.csproj
+++ b/Bootstrap/Bootstrap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>TestMyCode.CSharp.Bootstrap</RootNamespace>
     <Nullable>enable</Nullable>
     <AssemblyName>TestMyCode.CSharp.Bootstrap</AssemblyName>

--- a/Core/Compiler/CompilationFaultedException.cs
+++ b/Core/Compiler/CompilationFaultedException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TestMyCode.CSharp.Core.Compiler
 {

--- a/Core/Compiler/ProjectCompiler.cs
+++ b/Core/Compiler/ProjectCompiler.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
-using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using TestMyCode.CSharp.Core.Extensions;
-using Xunit.Runners;
 
 namespace TestMyCode.CSharp.Core.Compiler
 {

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>TestMyCode.CSharp.Core</RootNamespace>
     <Nullable>enable</Nullable>
     <AssemblyName>TestMyCode.CSharp.Core</AssemblyName>

--- a/Core/Data/TestProjectData.cs
+++ b/Core/Data/TestProjectData.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
 using TestMyCode.CSharp.API.Attributes;
 using Xunit;
 

--- a/Core/Extensions/BuildErrorEventArgsContext.cs
+++ b/Core/Extensions/BuildErrorEventArgsContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 
 namespace TestMyCode.CSharp.Core.Extensions
 {

--- a/Core/Test/MethodTestResult.cs
+++ b/Core/Test/MethodTestResult.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Xunit.Runners;
 
 namespace TestMyCode.CSharp.Core.Test

--- a/Core/Test/ProjectTestRunner.cs
+++ b/Core/Test/ProjectTestRunner.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using System.Text;
 using System.Threading;
 using TestMyCode.CSharp.Core.Data;
 using Xunit.Runners;

--- a/TestAssembly/TestAssembly.csproj
+++ b/TestAssembly/TestAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>TestMyCode.CSharp.TestAssembly</RootNamespace>
   </PropertyGroup>
 

--- a/TestAssembly/TestPassed.cs
+++ b/TestAssembly/TestPassed.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using TestMyCode.CSharp.API.Attributes;
 using Xunit;
 
 namespace TestMyCode.CSharp.TestAssembly

--- a/TestAssembly/TestPoints.cs
+++ b/TestAssembly/TestPoints.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using TestMyCode.CSharp.API.Attributes;
+﻿using TestMyCode.CSharp.API.Attributes;
 using Xunit;
 
 namespace TestMyCode.CSharp.TestAssembly

--- a/Tests/Points/TestPassed.cs
+++ b/Tests/Points/TestPassed.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Linq;
 using TestMyCode.CSharp.Core.Data;
 using TestMyCode.CSharp.Core.Test;

--- a/Tests/Points/TestPoints.cs
+++ b/Tests/Points/TestPoints.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using TestMyCode.CSharp.Core.Data;
 using Xunit;
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>TestMyCode.CSharp.Tests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5 support ends in about a week (May 8, 2022) so let's upgrade to .NET 6 which is a LTS and will last longer!